### PR TITLE
메인 페이지 구현

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,4 @@
 .App {
   text-align: center;
+  padding-bottom: 91px;
 }

--- a/src/components/navbar/Navbar.css
+++ b/src/components/navbar/Navbar.css
@@ -4,6 +4,7 @@
   bottom: 0;
   border-top: 1px solid #172C51;
   width: 100%;
+  background-color: white;
 }
 
 .navbar-inner {

--- a/src/components/post/ColumnPost.css
+++ b/src/components/post/ColumnPost.css
@@ -1,0 +1,44 @@
+.column-post {
+  background-color: white;
+  border-radius: 15px;
+  margin-bottom: 10px;
+  padding: 10px;
+}
+
+.column-post > a {
+  text-decoration: none;
+  color: black;
+  display: flex;
+}
+
+.column-post-image {
+  width: 80px;
+  height: 80px;
+  aspect-ratio: 1;
+  border-radius: 10px;
+  background: #D3EBF9;
+  margin: 0;
+  flex: none;
+  margin-right: 10px;
+}
+
+.column-post-info-title {
+  margin: 0;
+  text-align: left;
+  font-size: 16px;
+  margin-bottom: 5px;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.column-post-info-content {
+  margin: 0;
+  text-align: left;
+  font-size: 12px;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+}

--- a/src/components/post/ColumnPost.jsx
+++ b/src/components/post/ColumnPost.jsx
@@ -1,0 +1,27 @@
+import './ColumnPost.css';
+import { Link } from "react-router-dom";
+
+function ColumnPost(props) {
+  return (
+    <article className="column-post">
+      <Link>
+        <figure className="column-post-image">
+          {
+            props?.imagePath ? <img src={props.imagePath} alt="column" /> : null
+          }
+        </figure>
+        <div className="column-post-info">
+          <h4 className="column-post-info-title">
+            꾸준한 유산소 운동으로 심장을 건강하게!
+          </h4>
+          <p className="column-post-info-content">
+            유산소 운동은 무산소 운동의 반대말로 뜻은 에너지를 산소 대사를 통해 얻는 지속적인 힘을 내야 하는 운동을 말한다.
+            즉, 지방과 글리코겐을 완전연소 시킬 수 있는 강도로 행해지는 운동을 의미한다. 일반적으로 많은 산소를...
+          </p>
+        </div>
+      </Link>
+    </article>
+  )
+}
+
+export default ColumnPost;

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,8 @@
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100..900&display=swap');
+
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+  font-family: 'Noto Sans KR', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
   -webkit-font-smoothing: antialiased;

--- a/src/routes/Main.css
+++ b/src/routes/Main.css
@@ -1,0 +1,106 @@
+.main {
+  padding: 0 20px;
+  padding-top: 20px;
+  min-height: 100dvh;
+}
+
+.main-background {
+  background: linear-gradient(to bottom, #F59859, #FFFFFF 100%);
+  height: 100dvh;
+  width: 100vw;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: -1;
+}
+
+.main-percentage-section {
+  max-width: 262px;
+  margin: auto;
+  margin-bottom: 20px;
+}
+
+.main-percentage-section > p {
+  margin: 0;
+  font-size: 20px;
+  line-height: 1.6;
+}
+
+.main-percentage {
+  font-weight: 700;
+  font-size: 24px;
+}
+
+.main-status-section {
+  max-width: 262px;
+  margin: auto;
+  margin-bottom: 40px;
+}
+
+.main-status-circle {
+  width: 100%;
+  aspect-ratio: 1;
+  border: 2px solid #FFFFFF;
+  border-radius: 100%;
+  background: radial-gradient(#FFFFFF 0%, #F59859 80%);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  position: relative;
+  align-items: center;
+}
+
+.main-status {
+  color: white;
+  font-weight: 900;
+  font-size: 50px;
+  -webkit-text-stroke: 4px black;
+  margin: 0;
+}
+
+.main-status-inner {
+  color: white;
+  font-weight: 900;
+  font-size: 50px;
+  margin: 0;
+  -webkit-text-stroke: 0;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.main-factor-wrapper {
+  display: flex;
+  margin: 0 auto;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  bottom: 30px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
+}
+
+.main-factor-title {
+  font-size: 16px;
+  font-weight: 300;
+}
+
+.main-factor-item {
+  font-size: 16px;
+  text-align: left;
+}
+
+.main-column-container {
+  max-width: 700px;
+  margin: auto;
+}
+
+.main-column-container-title {
+  text-align: left;
+  margin-bottom: 10px;
+  font-weight: 400;
+  overflow: hidden;
+}

--- a/src/routes/Main.css
+++ b/src/routes/Main.css
@@ -88,6 +88,10 @@
   font-weight: 300;
 }
 
+.main-factor-list {
+  padding-left: 30px;
+}
+
 .main-factor-item {
   font-size: 16px;
   text-align: left;

--- a/src/routes/Main.jsx
+++ b/src/routes/Main.jsx
@@ -1,8 +1,41 @@
+import './Main.css';
+import ColumnPost from "../components/post/ColumnPost";
+
 function Main(props) {
   return (
-    <div>
-      <h1>메인 페이지</h1>
-    </div>
+    <main className="main">
+      <section className="main-percentage-section">
+        <p><span className="main-user-name">OOO</span>님의 뇌졸중 발병 확률은</p>
+        <p><span className="main-percentage">00</span>% 입니다.</p>
+      </section>
+      <section className="main-status-section">
+        <div className="main-status-circle">
+          <h1 className="main-status">
+            주의
+          </h1>
+          <h1 className="main-status-inner">주의</h1>
+          <div className="main-factor-wrapper">
+            <h3 className="main-factor-title">주요 요인</h3>
+            <ul className="main-factor-list">
+              <li className="main-factor-item">체중 감량 필요</li>
+              <li className="main-factor-item">높은 연령대</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+      <section className="main-column-container">
+        <h3 className="main-column-container-title"><span className="main-user-name">OOO</span>님에게 추천드리는 조언 칼럼</h3>
+        <ColumnPost />
+        <ColumnPost />
+        <ColumnPost />
+        <ColumnPost />
+        <ColumnPost />
+        <ColumnPost />
+        <ColumnPost />
+        <ColumnPost />
+      </section>
+      <div className="main-background"></div>
+    </main>
   )
 }
 


### PR DESCRIPTION
## 개발 내용
- 메인 페이지 레이아웃 구현
- 밑에 칼럼 리스트는 컴포넌트로 작성
- Navbar 배경 없어서 메인 컨텐츠랑 겹쳐 보이던 거 수정 (배경색 추가)
- 폰트 추가 (Noto Sans KR)
## 구현 화면
![image](https://github.com/JongHyeok-Park/cva-predictor/assets/114932050/4526e837-ccce-4c82-a2c8-94f9a5a6c26a)
## 기타
주요 요인 부분에 리스트 항목이 3개 이상이 되면 원에서 내용이 벗어날 수 있습니다. 디자인을 수정하거나 3개 이상 안 나오도록 해야할 것 같네요.