### PR TITLE
카카오 지도 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.23.1",
         "react-scripts": "5.0.1",
-        "web-vitals": "^2.1.4"
+        "web-vitals": "^2.1.4",
+        "zustand": "^4.5.2"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -17371,6 +17372,14 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -18455,6 +18464,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.2.tgz",
+      "integrity": "sha512-2cN1tPkDVkwCy5ickKrI7vijSjPksFRfqS6237NzT0vqSsztTNnQdHw9mmN7uBdk3gceVXU0a+21jFzFzAc9+g==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.23.1",
     "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "zustand": "^4.5.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/public/index.html
+++ b/public/index.html
@@ -27,6 +27,8 @@
 
     <!-- Kakao map -->
     <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%REACT_APP_KAKAO_MAP_API_KEY%"></script>
+    <script src="http://t1.daumcdn.net/mapjsapi/js/main/4.4.18/kakao.js"></script>
+
     <title>CVA Predictor</title>
   </head>
   <body>

--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,9 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+
+    <!-- Kakao map -->
+    <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%REACT_APP_KAKAO_MAP_API_KEY%"></script>
     <title>CVA Predictor</title>
   </head>
   <body>

--- a/src/api/kakaoMapApi.js
+++ b/src/api/kakaoMapApi.js
@@ -13,4 +13,19 @@ const getAddressApi = async (keyword) => {
   return res.json();
 }
 
-export { getAddressApi };
+const getPlaceInfoApi = async (keyword) => {
+  const res = await fetch(`https://dapi.kakao.com/v2/local/search/keyword.json?query=${keyword}`, {
+    headers: {
+      authorization: `KakaoAK ${process.env.REACT_APP_REST_API_KEY}`
+    }
+  });
+
+  if (!res.ok) {
+    const message = await res.text();
+    throw new Error(message);
+  };
+
+  return res.json();
+}
+
+export { getAddressApi, getPlaceInfoApi };

--- a/src/api/kakaoMapApi.js
+++ b/src/api/kakaoMapApi.js
@@ -1,0 +1,16 @@
+const getAddressApi = async (keyword) => {
+  const res = await fetch(`https://dapi.kakao.com/v2/local/search/address.json?query=${keyword}&analyze_type=similar`, {
+    headers: {
+      authorization: `KakaoAK ${process.env.REACT_APP_REST_API_KEY}`
+    }
+  });
+
+  if (!res.ok) {
+    const message = await res.text();
+    throw new Error(message);
+  };
+
+  return res.json();
+}
+
+export { getAddressApi };

--- a/src/components/modal/SearchModal.css
+++ b/src/components/modal/SearchModal.css
@@ -3,10 +3,20 @@
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);
-  padding: 100px;
+  padding: 20px 50px;
   background: white;
   border-radius: 20px;
   box-shadow: 0 0 10px #d9d9d9;
+  max-width: 500px;
+  width: 80vw;
+  box-sizing: border-box;
+}
+
+.search-modal-inner {
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  position: relative;
 }
 
 .address-list-wrapper {
@@ -16,4 +26,35 @@
   border: 1px solid #eee;
   list-style: none;
   margin: 0;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: left;
+}
+
+.search-modal-title {
+  margin: 0;
+  margin-bottom: 15px;
+  font-weight: 400;
+  font-size: 20px;
+}
+
+.search-modal-input {
+  border: 1px solid #172C51;
+  border-radius: 13px;
+  padding: 5px;
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 7px 14px;
+}
+
+.search-modal-cancle-btn {
+  background: #C4C4C4;
+  padding: 5px 30px;
+  border: none;
+  border-radius: 5px;
+  font-size: 20px;
+  font-weight: bold;
+  color: white;
+  margin-top: 10px;
 }

--- a/src/components/modal/SearchModal.css
+++ b/src/components/modal/SearchModal.css
@@ -1,0 +1,19 @@
+.search-modal {
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  padding: 100px;
+  background: white;
+  border-radius: 20px;
+  box-shadow: 0 0 10px #d9d9d9;
+}
+
+.address-list-wrapper {
+  position: absolute;
+  background: white;
+  padding: 0;
+  border: 1px solid #eee;
+  list-style: none;
+  margin: 0;
+}

--- a/src/components/modal/SearchModal.jsx
+++ b/src/components/modal/SearchModal.jsx
@@ -21,26 +21,28 @@ function SearchModal(props) {
 
   return (
     <section className="search-modal">
-      <h4>주소를 입력해주세요.</h4>
-      <input type="text" onChange={(e) => {
-        setInput(e.target.value)
-      }}/>
-      {
-        addressList.length > 0 ? (
-          <ul className='address-list-wrapper'>
-            {
-              addressList.map((item, i) => {
-                return (
-                  <AddressItem address={item} setShowModal={props.setShowModal} key={i} />
-                )
-              })
-            }
-          </ul>
-        ) : null
-      }
-      <button type="button" onClick={() => {
-        props.setShowModal(false);
-      }}>취소</button>
+      <div className='search-modal-inner'>
+        <h4 className='search-modal-title'>주소를 입력해주세요.</h4>
+        <input className='search-modal-input' type="text" onChange={(e) => {
+          setInput(e.target.value)
+        }}/>
+        {
+          addressList.length > 0 ? (
+            <ul className='address-list-wrapper'>
+              {
+                addressList.map((item, i) => {
+                  return (
+                    <AddressItem address={item} setShowModal={props.setShowModal} key={i} />
+                  )
+                })
+              }
+            </ul>
+          ) : null
+        }
+        <button className='search-modal-cancle-btn' type="button" onClick={() => {
+          props.setShowModal(false);
+        }}>취소</button>
+      </div>
     </section>
   )
 }

--- a/src/components/modal/SearchModal.jsx
+++ b/src/components/modal/SearchModal.jsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import './SearchModal.css';
+import { getAddressApi } from '../../api/kakaoMapApi';
+import AddressItem from '../post/AddressItem';
+
+function SearchModal(props) {
+  const [input, setInput] = useState();
+  const [addressList, setAddressList] = useState([]);
+  
+  useEffect(() => {
+    if (input?.length > 0) {
+      getAddressApi(input)
+      .then((data) => {
+        setAddressList(data.documents);
+      })
+      .catch((error) => {
+        console.error(error.message);
+      })
+    }
+  }, [input])
+
+  return (
+    <section className="search-modal">
+      <h4>주소를 입력해주세요.</h4>
+      <input type="text" onChange={(e) => {
+        setInput(e.target.value)
+      }}/>
+      {
+        addressList.length > 0 ? (
+          <ul className='address-list-wrapper'>
+            {
+              addressList.map((item, i) => {
+                return (
+                  <AddressItem address={item} setShowModal={props.setShowModal} key={i} />
+                )
+              })
+            }
+          </ul>
+        ) : null
+      }
+      <button type="button" onClick={() => {
+        props.setShowModal(false);
+      }}>취소</button>
+    </section>
+  )
+}
+
+export default SearchModal;

--- a/src/components/post/AddressItem.css
+++ b/src/components/post/AddressItem.css
@@ -1,0 +1,8 @@
+.address-item {
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.address-item:hover {
+  background-color: #eee;
+}

--- a/src/components/post/AddressItem.css
+++ b/src/components/post/AddressItem.css
@@ -1,6 +1,8 @@
 .address-item {
   font-size: 12px;
   cursor: pointer;
+  width: 100%;
+  padding: 2px 10px;
 }
 
 .address-item:hover {

--- a/src/components/post/AddressItem.jsx
+++ b/src/components/post/AddressItem.jsx
@@ -1,0 +1,18 @@
+import useAddressStore from '../../store/AddressStore';
+import './AddressItem.css';
+
+function AddressItem(props) {
+  const setAddress = useAddressStore((state) => state.setAddress);
+
+  return (
+    <li className="address-item" onClick={() => {
+      console.log(props.address);
+      setAddress(props.address);
+      props.setShowModal(false);
+    }}>
+      {props.address.address_name}
+    </li>
+  )
+}
+
+export default AddressItem;

--- a/src/components/post/HospitalItem.jsx
+++ b/src/components/post/HospitalItem.jsx
@@ -1,7 +1,24 @@
 import { Link } from "react-router-dom";
 import './HospitalItem.css';
+import { useEffect, useState } from "react";
+import { getPlaceInfoApi } from "../../api/kakaoMapApi";
 
 function HospitalItem(props) {
+  const [lat, lng] = [128.604702568416, 35.8662511316347]
+  const name = '경북대학교 병원';
+  const [placeId, setPlaceId] = useState();
+
+  useEffect(() => {
+    getPlaceInfoApi(name)
+      .then((data) => {
+        console.log(data.documents);
+        setPlaceId(data.documents[0]?.id);
+      })
+      .catch((error) => {
+        console.error(error.message);
+      })
+  })
+
   return (
     <article className="hospital-item">
       <div className="hospital-item-type-icon">
@@ -9,12 +26,13 @@ function HospitalItem(props) {
       </div>
       <div className="hospital-item-info">
         <div className="hospital-item-info-main">
-          <h4 className="hospital-name">경북대학교 병원</h4>
+          <h4 className="hospital-name">{name}</h4>
           <span className="hospital-item-distance">230m</span>
         </div>
         <div className="hospital-item-info-secondary">
           <p className="hospital-item-address">대구광역시 중구 동덕로 130</p>
-          <Link className="hospital-item-map-link">지도 보기 &gt;</Link>
+          <a className="hospital-item-map-link" href={`https://map.kakao.com/link/map/${placeId}`} target="_blank">지도 보기 &gt;</a>
+          {/* <Link className="hospital-item-map-link" to={`/map?lat=${128.604702568416}&lng=${35.8662511316347}`}>지도 보기 &gt;</Link> */}
         </div>
       </div>
     </article>

--- a/src/components/post/HospitalItem.jsx
+++ b/src/components/post/HospitalItem.jsx
@@ -1,17 +1,14 @@
-import { Link } from "react-router-dom";
 import './HospitalItem.css';
 import { useEffect, useState } from "react";
 import { getPlaceInfoApi } from "../../api/kakaoMapApi";
 
 function HospitalItem(props) {
-  const [lat, lng] = [128.604702568416, 35.8662511316347]
   const name = '경북대학교 병원';
   const [placeId, setPlaceId] = useState();
 
   useEffect(() => {
     getPlaceInfoApi(name)
       .then((data) => {
-        console.log(data.documents);
         setPlaceId(data.documents[0]?.id);
       })
       .catch((error) => {
@@ -31,8 +28,7 @@ function HospitalItem(props) {
         </div>
         <div className="hospital-item-info-secondary">
           <p className="hospital-item-address">대구광역시 중구 동덕로 130</p>
-          <a className="hospital-item-map-link" href={`https://map.kakao.com/link/map/${placeId}`} target="_blank">지도 보기 &gt;</a>
-          {/* <Link className="hospital-item-map-link" to={`/map?lat=${128.604702568416}&lng=${35.8662511316347}`}>지도 보기 &gt;</Link> */}
+          <a className="hospital-item-map-link" href={`https://map.kakao.com/link/map/${placeId}`} target="_blank" rel="noreferrer">지도 보기 &gt;</a>
         </div>
       </div>
     </article>

--- a/src/routes/Hospital.jsx
+++ b/src/routes/Hospital.jsx
@@ -1,16 +1,31 @@
+import { useState } from "react";
 import HospitalItem from "../components/post/HospitalItem";
 import Top from "../components/top/Top";
 import './Hospital.css';
+import SearchModal from "../components/modal/SearchModal";
+import useAddressStore from "../store/AddressStore";
 
 function Hospital(props) {
+  const [showModal, setShowModal] = useState(false);
+  const address = useAddressStore((state) => state.address);
+
+
+  const onClickLocationBtn = () => {
+    setShowModal(true);
+  }
+
   return (
     <main className="hospital">
       <Top title="주변 병원" />
       <section className="hospital-address-section">
         <div className="hospital-address-wrapper">
           <span className="hospital-current-location-title">현재 위치</span>
-          <span className="hospital-current-location">대구광역시 북구 대학로 80</span>
-          <button type="button" className="hospital-current-location-btn">직접 입력 &gt;</button>
+          <span className="hospital-current-location">
+            {
+              address ? address.address_name : "대구광역시 북구 대학로 80"
+            }  
+          </span>
+          <button type="button" className="hospital-current-location-btn" onClick={onClickLocationBtn}>직접 입력 &gt;</button>
         </div>
       </section>
       <section className="hospital-list-section">
@@ -18,6 +33,9 @@ function Hospital(props) {
         <HospitalItem />
         <HospitalItem />
       </section>
+      {
+        showModal ? <SearchModal setShowModal={setShowModal} /> : null
+      }
     </main>
   )
 }

--- a/src/store/AddressStore.js
+++ b/src/store/AddressStore.js
@@ -1,0 +1,8 @@
+import { create } from 'zustand'
+
+const useAddressStore = create((set) => ({
+  address: {},
+  setAddress: (newAddress) => set({ address: newAddress }),
+}))
+
+export default useAddressStore;


### PR DESCRIPTION
## 개발 내용
- 카카오 지도 API와 연동하였습니다.
- 병원 페이지에서 "직접 입력 >" 버튼을 누르면 주소를 입력할 수 있는 창이 뜹니다.
- 주소를 입력하고 나오는 리스트를 클릭하면 해당 주소로 적용됩니다.
- 병원 아이템에서 "지도 보기 >"을 누르면 카카오 지도 페이지가 나오며 해당 병원이 표출됩니다.
- 전역 상태 관리를 위해 Zustand 모듈 설치했습니다. (dev 브랜치 업데이트 하시면 "npm install" 한번 실행하셔야 할겁니다.) 

## 구현 화면
![image](https://github.com/JongHyeok-Park/cva-predictor/assets/114932050/aacbc7c0-6a80-49ec-b543-a658f65cd10a)

## 기타
- 해당 주소 검색 창 디자인 해주실 수 있으시면 좀 부탁드려도 될까요? 일단은 임시로 저렇게 해뒀습니다.
- 특정 병원 ID값으로 지도를 띄우는데 ID는 나중에 백엔드에 요청해야 할 것 같습니다.