### PR TITLE
카카오 지도 서비스 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "axios": "^1.7.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-kakao-maps-sdk": "^1.1.27",
         "react-router-dom": "^6.23.1",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4",
@@ -12354,6 +12355,11 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/kakao.maps.d.ts": {
+      "version": "0.1.39",
+      "resolved": "https://registry.npmjs.org/kakao.maps.d.ts/-/kakao.maps.d.ts-0.1.39.tgz",
+      "integrity": "sha512-KXENJ8hHYtjb5G+0vf8TXx/PwWW4j5ndDiQTSMvGtF7EFWu2P3N/+Zivcj9/UKn3j29Iz/sIUaA7WL8Ug3IDGQ=="
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -15121,6 +15127,19 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "node_modules/react-kakao-maps-sdk": {
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/react-kakao-maps-sdk/-/react-kakao-maps-sdk-1.1.27.tgz",
+      "integrity": "sha512-1EwYkYsjTDRFqysKStDasFMrFTXcLx2AyRlqMoWD7ONWhRqpjx9M874hkhEEHrnypP2eSIhhDLe0EiSKp3bd2Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.15",
+        "kakao.maps.d.ts": "^0.1.39"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18",
+        "react-dom": "^16.8 || ^17 || ^18"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "axios": "^1.7.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-kakao-maps-sdk": "^1.1.27",
     "react-router-dom": "^6.23.1",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4",

--- a/public/index.html
+++ b/public/index.html
@@ -25,10 +25,6 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
 
-    <!-- Kakao map -->
-    <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%REACT_APP_KAKAO_MAP_API_KEY%"></script>
-    <script src="http://t1.daumcdn.net/mapjsapi/js/main/4.4.18/kakao.js"></script>
-
     <title>CVA Predictor</title>
   </head>
   <body>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import Post from './routes/Post';
 import MyInfo from './routes/MyInfo';
 import Hospital from './routes/Hospital';
 import Navbar from './components/navbar/Navbar';
+import MapView from './routes/MapView';
 
 function App() {
   return (
@@ -18,6 +19,7 @@ function App() {
         <Route path='/update' element={<Update />} />
         <Route path='/info' element={<MyInfo />} />
         <Route path='/hospital' element={<Hospital />} />
+        <Route path='/map' element={<MapView />} />
       </Routes>
       <Navbar />
     </div>

--- a/src/components/navbar/Navbar.css
+++ b/src/components/navbar/Navbar.css
@@ -5,6 +5,7 @@
   border-top: 1px solid #172C51;
   width: 100%;
   background-color: white;
+  z-index: 999;
 }
 
 .navbar-inner {

--- a/src/components/post/HospitalItem.jsx
+++ b/src/components/post/HospitalItem.jsx
@@ -1,20 +1,8 @@
 import './HospitalItem.css';
-import { useEffect, useState } from "react";
-import { getPlaceInfoApi } from "../../api/kakaoMapApi";
+import { Link } from 'react-router-dom';
 
 function HospitalItem(props) {
   const name = '경북대학교 병원';
-  const [placeId, setPlaceId] = useState();
-
-  useEffect(() => {
-    getPlaceInfoApi(name)
-      .then((data) => {
-        setPlaceId(data.documents[0]?.id);
-      })
-      .catch((error) => {
-        console.error(error.message);
-      })
-  })
 
   return (
     <article className="hospital-item">
@@ -28,7 +16,7 @@ function HospitalItem(props) {
         </div>
         <div className="hospital-item-info-secondary">
           <p className="hospital-item-address">대구광역시 중구 동덕로 130</p>
-          <a className="hospital-item-map-link" href={`https://map.kakao.com/link/map/${placeId}`} target="_blank" rel="noreferrer">지도 보기 &gt;</a>
+          <Link to={'/map?lat=35.8662511316347&lng=128.604702568416'} className="hospital-item-map-link">지도 보기 &gt;</Link>
         </div>
       </div>
     </article>

--- a/src/routes/MapView.jsx
+++ b/src/routes/MapView.jsx
@@ -1,0 +1,33 @@
+import { Map, MapMarker, MapTypeControl, ZoomControl, useKakaoLoader } from "react-kakao-maps-sdk";
+import { useSearchParams } from "react-router-dom";
+
+function MapView(props) {
+  useKakaoLoader({
+    appkey: process.env.REACT_APP_KAKAO_MAP_API_KEY,
+    libraries: ["clusterer", "drawing", "services"]
+  });
+  const [searchParams] = useSearchParams();
+  const [lat, lng] = [searchParams.get('lat'), searchParams.get('lng')]
+  const center = {
+    lat: lat,
+    lng: lng
+  }
+
+  return (
+    <main className="map-wrapper">
+      <Map 
+        center={center}
+        isPanto={true}
+        style={{ width: "100%", height: "100vh" }}
+      >
+        <MapMarker position={center}>
+          {/* <div style={{color:"#000"}}>경북대학교 병원</div> */}
+        </MapMarker>
+        <MapTypeControl position={"TOPRIGHT"} />
+        <ZoomControl position={"RIGHT"} />
+      </Map>
+    </main>
+  )
+}
+
+export default MapView;

--- a/src/store/LatLngStore.js
+++ b/src/store/LatLngStore.js
@@ -1,0 +1,11 @@
+import { create } from 'zustand'
+
+const useLatLngStore = create((set) => ({
+  latLng: {
+    lat: 128.604702568416,
+    lng: 35.8662511316347
+  },
+  setLatLng: (newLat, newLng) => set({ lat: newLat, lng: newLng }),
+}))
+
+export default useLatLngStore;


### PR DESCRIPTION
## 개발 내용
- 원래 카카오 외부에 지도 서비스를 이용했습니다.
- 저희 페이지 안에서 카카오 sdk 이용해서 볼 수 있도록 구현했습니다.
## 구현 화면
![image](https://github.com/JongHyeok-Park/cva-predictor/assets/114932050/97994cb4-733b-4526-a410-4db06a4f3800)
## 세팅
- 카카오 sdk 모듈 추가로 설치해서 패키지 설치 필요합니다. 아래 명령어 입력해주세요.
`npm install`
